### PR TITLE
disable cgo on centos 5

### DIFF
--- a/centos_5.bootstrap
+++ b/centos_5.bootstrap
@@ -11,6 +11,8 @@ ENV GOLANG_VERSION=[{GOLANG_VERSION}]
 
 ENV GOROOT=/usr/local/go
 
+ENV CGO_ENABLED=0
+
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \

--- a/centos_5_test.dockerfile
+++ b/centos_5_test.dockerfile
@@ -8,6 +8,8 @@ ENV GOLANG_VERSION=[{GOLANG_VERSION}]
 
 ENV GOROOT=/usr/local/go
 
+ENV CGO_ENABLED=0
+
 RUN yum install -y curl && \
     cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
This should disable cgo for the lfs docker gauntlet on centos 5. I think :)