### PR TITLE
bump go to 1.5.3

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.5.1}
+: ${GOLANG_VERSION:=1.5.3}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.5.1}
+: ${GOLANG_VERSION:=1.5.3}
 export GOLANG_VERSION
 
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-v1.0.0}


### PR DESCRIPTION
Besides it being a new version (and new is always better, especially in software), there's also a [security fix in it](https://groups.google.com/forum/#!topic/golang-announce/MEATuOi_ei4). :feelsgood: 